### PR TITLE
inherit env from $VIRTUAL_ENV if no name specified

### DIFF
--- a/ftplugin/python/virtualenv.vim
+++ b/ftplugin/python/virtualenv.vim
@@ -136,3 +136,7 @@ endfunction
 "}}}
 
 let &cpo = s:save_cpo
+
+if exists("g:virtualenv_autoworkon")
+    call s:VirtualEnvActivate('')
+endif


### PR DESCRIPTION
In the case that the user doesn't specify a virtualenv name to VirtualEnvActivate() and $PROJECT_HOME is not defined, inherit the underlying shell's virtualenv via $VIRTUAL_ENV (if it exists).

So, if I do the following (assuming $PROJECT_HOME is not configured):

(launch terminal)
$ workon myproj
$ vim /path/to/file.py
:VirtualEnvActivate

This will load the myproj virtual environment into VIM's python interpreter.
