### PR TITLE
Alternative Statusline conditioned to filetype

### DIFF
--- a/doc/virtualenv.txt
+++ b/doc/virtualenv.txt
@@ -47,6 +47,10 @@ Example: >
 To use the statusline flag, this must appear in your |'statusline'| setting: >
     %{VirtualEnvStatusline()}
 <
+Alternatively, you may display the statusline flag only if the current
+filetype is python using: >
+    %{VirtualEnvCondStatusline()}
+<
 The content is derived from the |g:virtualenv_stl_format| variable.
 
 vim:tw=78:et:ft=help:norl:

--- a/plugin/virtualenv.vim
+++ b/plugin/virtualenv.vim
@@ -137,6 +137,14 @@ function! VirtualEnvStatusline() "{{{1
     endif
 endfunction
 
+function! VirtualEnvCondStatusline() "{{{1
+  if &filetype ==# 'python'
+    return VirtualEnvStatusline()
+  else
+    return ''
+  endif
+endfunction
+
 "}}}
 
 if g:virtualenv_auto_activate == 1


### PR DESCRIPTION
I added an extra function that will only return VirtualEnvStatusline if the current ft=python.

I work with Ruby and Java too, so I didn't want to clutter my statusline. This way, it only shows the active virtualenv when working with Python buffers.

I know, this is a cosmetic improvement, at best. Feel free to ignore it.
