### PR TITLE
virtualenv#activate: only change $PATH if necessary

### DIFF
--- a/autoload/virtualenv.vim
+++ b/autoload/virtualenv.vim
@@ -21,7 +21,13 @@ function! virtualenv#activate(name) "{{{1
     endif
     call virtualenv#deactivate()
     let g:virtualenv_path = $PATH
-    let $PATH = bin.':'.$PATH
+
+    " Prepend bin to PATH, but only if it's not there already
+    " (activate_this does this also, https://github.com/pypa/virtualenv/issues/14)
+    if $PATH[:len(bin)] != bin.':'
+        let $PATH = bin.':'.$PATH
+    endif
+
     python << EOF
 import vim, os, sys
 activate_this = vim.eval('l:script')


### PR DESCRIPTION
If the first $PATH entry is the virtualenv's "bin" dir already, skip
prepending it once more.
