### PR TITLE
created .gitignore, added /doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
For those that use git to manage their vim dotfiles with many submodules, but also have plugins that will automatically create ctags for all plugin docs, not having a `.gitignore` file to manage the automatically generated ctags file in `/doc/tags` creates an annoying mismatch between the local repository and your origin remote. We can either include the /doc/tags file or ignore it in `.gitignore`; this seemed like the less intrusive. 
