### PR TITLE
Use subprocess to obtain correct site_packages #20

### DIFF
--- a/autoload/virtualenv.vim
+++ b/autoload/virtualenv.vim
@@ -31,14 +31,14 @@ function! virtualenv#activate(name) "{{{1
     python << EOF
 import vim, os, sys, subprocess
 activate_this = vim.eval('l:script')
-base = os.path.dirname(os.path.dirname(os.path.abspath(activate_this)))
-base_bin = vim.eval('l:bin')
-env_version = subprocess.check_output(os.path.join(base_bin, 'python') + ' -V', shell=True)
+virt_base = os.path.dirname(os.path.dirname(os.path.abspath(activate_this)))
+virt_base_bin = vim.eval('l:bin')
+env_version = subprocess.check_output(os.path.join(virt_base_bin, 'python') + ' -V', shell=True)
 env_version = env_version.split()[1][:3]
 if sys.platform == 'win32':
-    site_packages = os.path.join(base, 'Lib', 'site-packages')
+    site_packages = os.path.join(virt_base, 'Lib', 'site-packages')
 else:
-    site_packages = os.path.join(base, 'lib', 'python%s' % env_version, 'site-packages')
+    site_packages = os.path.join(virt_base, 'lib', 'python%s' % env_version, 'site-packages')
 prev_sys_path = list(sys.path)
 execfile(activate_this, dict(__file__=activate_this))
 prev_pythonpath = os.environ.setdefault('PYTHONPATH', '')

--- a/autoload/virtualenv.vim
+++ b/autoload/virtualenv.vim
@@ -29,12 +29,20 @@ function! virtualenv#activate(name) "{{{1
     endif
 
     python << EOF
-import vim, os, sys
+import vim, os, sys, subprocess
 activate_this = vim.eval('l:script')
+base = os.path.dirname(os.path.dirname(os.path.abspath(activate_this)))
+base_bin = vim.eval('l:bin')
+env_version = subprocess.check_output(os.path.join(base_bin, 'python') + ' -V', shell=True)
+env_version = env_version.split()[1][:3]
+if sys.platform == 'win32':
+    site_packages = os.path.join(base, 'Lib', 'site-packages')
+else:
+    site_packages = os.path.join(base, 'lib', 'python%s' % env_version, 'site-packages')
 prev_sys_path = list(sys.path)
 execfile(activate_this, dict(__file__=activate_this))
 prev_pythonpath = os.environ.setdefault('PYTHONPATH', '')
-os.environ['PYTHONPATH'] += ':' + os.getcwd() + ':' + ':'.join(sys.path)
+os.environ['PYTHONPATH'] += ':' + os.getcwd() + ':' + site_packages
 EOF
     let g:virtualenv_name = name
 endfunction

--- a/autoload/virtualenv.vim
+++ b/autoload/virtualenv.vim
@@ -33,7 +33,7 @@ import vim, os, sys, subprocess
 activate_this = vim.eval('l:script')
 virt_base = os.path.dirname(os.path.dirname(os.path.abspath(activate_this)))
 virt_base_bin = vim.eval('l:bin')
-env_version = subprocess.check_output(os.path.join(virt_base_bin, 'python') + ' -V', shell=True)
+env_version = subprocess.check_output(os.path.join(virt_base_bin, 'python') + ' -V', stderr=subprocess.STDOUT, shell=True)
 env_version = env_version.split()[1][:3]
 if sys.platform == 'win32':
     site_packages = os.path.join(virt_base, 'Lib', 'site-packages')


### PR DESCRIPTION
I ran into issue #20 because I have vim compiled with python 2 but I want to use syntax checking (via syntastic #15) and autocompletion (via YouCompleteMe). This code limits the PYTHONPATH mangling to just the cwd plus the site_packages that would be appended to sys.path if the environment where activated using the default interpreter for that environment. On my box, I get results for syntastic with flake8 and YouCompleteMe. I expect that this will also solve the problem for Python3 virtualenvs with neocomplete or other plugins. 