### PR TITLE
Don't do directory lookups if env is active

### DIFF
--- a/autoload/virtualenv.vim
+++ b/autoload/virtualenv.vim
@@ -14,7 +14,11 @@ function! virtualenv#activate(name) "{{{1
     if len(name) == 0  "Couldn't figure it out, so DIE
         return
     endif
-    let bin = g:virtualenv_directory.'/'.name.'/bin'
+    if isdirectory($VIRTUAL_ENV)
+        let bin = $VIRTUAL_ENV.'/bin'
+    else
+        let bin = g:virtualenv_directory.'/'.name.'/bin'
+    endif
     let script = bin.'/activate_this.py'
     if !filereadable(script)
         return 0


### PR DESCRIPTION
When a virtualenv is active when starting vim, vim-virtualenv takes its name and tries to find it in the standard- locations. If it can't be found, the plugin continues as if no env would be active. With this commit, searching for  he env is disabled and the original path kept.