### PR TITLE
Improve 'deactivate' method to support inherited venvs

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -7,6 +7,8 @@ When using :python or :!python, it will only have access to the environment outs
 
 If compiled with python support, Vim will have a :python command, but this will be tied to whatever version is the default on your system. If this is the version of python that you use, or you're using a Linux distribution with a sensible package manager (like Debian or Ubuntu), you likely will not have to do anything more than install the plugin. If not, then you will likely have to recompile vim with your version of python.
 
+The plugin is even smart enough to handle situations where Vim inherits an active virtualenv from the shell. The plugin can switch between and deactivate those virtualenvs all the same.
+
 Usage examples
 ==============
 

--- a/plugin/virtualenv.vim
+++ b/plugin/virtualenv.vim
@@ -29,6 +29,14 @@ endif
 
 let g:virtualenv_directory = expand(g:virtualenv_directory)
 
+if len($VIRTUAL_ENV) != 0
+    let g:virtualenv_inherited_venv_bin = $VIRTUAL_ENV.'/bin'
+    let g:virtualenv_current_venv = g:virtualenv_inherited_venv_bin
+else
+    let g:virtualenv_inherited_venv_bin = ''
+    let g:virtualenv_current_venv = ''
+endif
+
 command! -bar VirtualEnvList :call virtualenv#list()
 command! -bar VirtualEnvDeactivate :call virtualenv#deactivate()
 command! -bar -nargs=? -complete=customlist,s:CompleteVirtualEnv VirtualEnvActivate :call virtualenv#activate(<q-args>)


### PR DESCRIPTION
Completely ravamped the way the plugin remembers old paths and
reinstates them. Instead of a "stash and replace" method for the entire
path (which accidently remembers inherited venv paths), now it will:
1. Detect inherited venvs using $VIRTUAL_ENV, remember them and set them
   as the "current venv"
2. Deactivate any previous (inherited or former "current" venvs) before
   activating any new ones
3. and do so by way of search and remove through the entire path for the
   paths we want to remove.

This method allows for a much more robust workflow where one can be free
to start/stop/switch the same venvs from the shell or within vim.

Also, I've decided to depreciate the redundant (and not so robust) way
of checking and prepending the new $PATH in virtualenv#activate(). As
already stated in the comments, 'activate_this.py' already does this.
