### PR TITLE
Set/clear $VIRTUAL_ENV on activate/deactivate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags

--- a/README.mkd
+++ b/README.mkd
@@ -39,6 +39,10 @@ You can even show the current virtualenv in the statusline with the included fun
 
 ![statusline](http://i.imgur.com/oxE70.png "Statusline")
 
+Or, for those with a properly configured Powerline (the virtualenv segment is not enabled by default), your virtualenv indicator will toggle on or off accordingly.
+
+![powerline_indicator](http://i.imgur.com/t6pGg7w.png "Powerline Indicator Toggled")
+
 For more detailed help
 
     :help virtualenv

--- a/autoload/virtualenv.vim
+++ b/autoload/virtualenv.vim
@@ -37,6 +37,7 @@ prev_pythonpath = os.environ.setdefault('PYTHONPATH', '')
 os.environ['PYTHONPATH'] += ':' + os.getcwd() + ':' + ':'.join(sys.path)
 EOF
     let g:virtualenv_name = name
+    let $VIRTUAL_ENV = g:virtualenv_directory.'/'.g:virtualenv_name
 endfunction
 
 function! virtualenv#deactivate() "{{{1
@@ -55,6 +56,7 @@ EOF
     endif
     unlet! g:virtualenv_name
     unlet! g:virtualenv_path
+    let $VIRTUAL_ENV = '' " can't delete parent variables
 endfunction
 
 function! virtualenv#list() "{{{1

--- a/autoload/virtualenv.vim
+++ b/autoload/virtualenv.vim
@@ -21,7 +21,13 @@ function! virtualenv#activate(name) "{{{1
     endif
     call virtualenv#deactivate()
     let g:virtualenv_path = $PATH
-    let $PATH = bin.':'.$PATH
+
+    " Prepend bin to PATH, but only if it's not there already
+    " (activate_this does this also, https://github.com/pypa/virtualenv/issues/14)
+    if $PATH[:len(bin)] != bin.':'
+        let $PATH = bin.':'.$PATH
+    endif
+
     python << EOF
 import vim, os, sys
 activate_this = vim.eval('l:script')

--- a/doc/virtualenv.txt
+++ b/doc/virtualenv.txt
@@ -51,4 +51,8 @@ To use the statusline flag, this must appear in your |'statusline'| setting: >
 <
 The content is derived from the |g:virtualenv_stl_format| variable.
 
+Powerline users can see their statuslines too. After configuring powerline
+according to its documentation to support a virtualenv segment, Powerline will
+read the value of $VIRTUAL_ENV and display it.
+
 vim:tw=78:et:ft=help:norl:


### PR DESCRIPTION
Set this so that other plugins that are configured to look for it
(Powerline) can now do that and behave accordingly.

Powerline was patched here:
https://github.com/Lokaltog/powerline/pull/896

To allow this functionality from it's end.

This patch also fixes #26.