### PR TITLE
Better relative path support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags

--- a/README.mkd
+++ b/README.mkd
@@ -39,6 +39,16 @@ You can even show the current virtualenv in the statusline with the included fun
 
 ![statusline](http://i.imgur.com/oxE70.png "Statusline")
 
+The plugin also supports relative paths for the location of your virtualenvs.
+Locations such as `./venv` or `../venv` are supported in case you like to
+package your virtualenvs inside or relative to your project code. Care is taken
+to ensure that this location exists before defaulting back to the value of
+`$WORKON_HOME` if you are a virtualenvwrapper user or `~/.virtualenvs` as a
+last resort. This has the pleasant side-effect of allowing access to two sets
+of virtualenvs depending on what your current directory is; a project-specific
+set of virtualenvs located in the relative location, or a general set located
+in either of the other two fallback locations.
+
 For more detailed help
 
     :help virtualenv

--- a/autoload/virtualenv.vim
+++ b/autoload/virtualenv.vim
@@ -1,4 +1,5 @@
 function! virtualenv#activate(name) "{{{1
+    call virtualenv#rel_dir_resolve()
     let name = a:name
     if len(name) == 0  "Figure out the name based on current file
         if isdirectory($VIRTUAL_ENV)
@@ -72,6 +73,7 @@ function! virtualenv#statusline() "{{{1
 endfunction
 
 function! virtualenv#names(prefix) "{{{1
+    call virtualenv#rel_dir_resolve()
     let venvs = []
     for dir in split(glob(g:virtualenv_directory.'/'.a:prefix.'*'), '\n')
         if !isdirectory(dir)
@@ -84,4 +86,22 @@ function! virtualenv#names(prefix) "{{{1
         call add(venvs, fnamemodify(dir, ':t'))
     endfor
     return venvs
+endfunction
+
+function! virtualenv#rel_dir_resolve() "{{{1
+    if has('unix')
+        let g:virtualenv_directory_test = system("echo -n $(readlink -mn \"".g:virtualenv_directory_orig."\")")
+    elseif has('macunix')
+        let g:virtualenv_directory_test = system("echo -n $(greadlink -mn \"".g:virtualenv_directory_orig."\")")
+    endif
+    if !isdirectory(g:virtualenv_directory_test)
+        if isdirectory($WORKON_HOME)
+            let g:virtualenv_directory = $WORKON_HOME
+        else
+            let g:virtualenv_directory = '~/.virtualenvs'
+        endif
+    else
+        let g:virtualenv_directory = g:virtualenv_directory_test
+    endif
+    let g:virtualenv_directory = expand(g:virtualenv_directory)
 endfunction

--- a/doc/virtualenv.txt
+++ b/doc/virtualenv.txt
@@ -33,6 +33,17 @@ g:virtualenv_directory                           *g:virtualenv_directory*
     user and you have $WORKON_HOME set, it will default to this. Otherwise it
     will default to ~/.virtualenvs.
 
+    Support is also given for relative paths. So if you prefer to package your
+    virtualenvs within your project ('./venv') or in the parent directory
+    relative to your project root ('../venv'), the virtualenv plugin should be
+    able to find those virtualenvs when your cwd is set appropriately.
+
+    As part of this support, when a new current directory is set, the plugin
+    will check that the expanded relative directory exists before doing
+    anything. If the directory does not exist, the plugin will gracefully
+    default back to the value of $WORKON_HOME if it is set, or ~/.virtualenvs
+    as a last resort.
+
 g:virtualenv_auto_activate                       *g:virtualenv_auto_activate*
     If set, an attempt will be made to detect any active virtualenv, and
     activate it.

--- a/plugin/virtualenv.vim
+++ b/plugin/virtualenv.vim
@@ -25,9 +25,14 @@ if !exists("g:virtualenv_directory")
     else
         let g:virtualenv_directory = '~/.virtualenvs'
     endif
+else
+    let g:virtualenv_directory_orig = g:virtualenv_directory
+    if !isdirectory(g:virtualenv_directory)
+        let g:virtualenv_directory = '~/.virtualenvs'
+    endif
 endif
 
-let g:virtualenv_directory = expand(g:virtualenv_directory)
+call virtualenv#rel_dir_resolve()
 
 command! -bar VirtualEnvList :call virtualenv#list()
 command! -bar VirtualEnvDeactivate :call virtualenv#deactivate()


### PR DESCRIPTION
If a relative path is set, the plugin will check that this relative path
exists first before running any of it's functions. If the pat does not
exist, then it will gracefully default back to the value of
`$WORKON_HOME` first, then `~/.virtualenvs` last. This is is done based
on what vim's CWD is.

note: I think I squashed wrong because it wants to commit 01a52ab as well for some reason. But I haven't made any changes to that commit FYI so you can ignore it I guess.
