### PR TITLE
virtualenv#activate: echoerr, if not "silent"

### DIFF
--- a/autoload/virtualenv.vim
+++ b/autoload/virtualenv.vim
@@ -8,8 +8,9 @@ elseif has('python3')
     python3 import pyvenv
 endif
 
-function! virtualenv#activate(name)
-    let name = a:name
+function! virtualenv#activate(...)
+    let name   = a:0 > 0 ? a:1 : ''
+    let silent = a:0 > 1 ? a:2 : 0
     let env_dir = ''
     if len(name) == 0  "Figure out the name based on current file
         if isdirectory($VIRTUAL_ENV)
@@ -29,6 +30,9 @@ function! virtualenv#activate(name)
 
     "Couldn't figure it out, so DIE
     if !isdirectory(env_dir)
+        if !silent
+            echoerr "No virtualenv could be auto-detected and activated."
+        endif
         return
     endif
 

--- a/plugin/virtualenv.vim
+++ b/plugin/virtualenv.vim
@@ -47,7 +47,7 @@ function! VirtualEnvStatusline()
 endfunction
 
 if g:virtualenv_auto_activate == 1
-    call virtualenv#activate('')
+    call virtualenv#activate('', 1)
 endif
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
Make `virtualenv#activate` silent when called via
`g:virtualenv_auto_activate`, but display an error when called manually.