### PR TITLE
gitignore: ignore Python byte compiled files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 /doc/tags
+
+### Template taken from github's gitignore repository
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class


### PR DESCRIPTION
Ignore the byte compiled files made by Vim's embedded python
interpreter.