### PR TITLE
add hard-coded activate_this.py content

### DIFF
--- a/autoload/pyvenv.py
+++ b/autoload/pyvenv.py
@@ -37,11 +37,15 @@ def activate(env):
     prev_syspath = list(sys.path)
     activate = os.path.join(env, (sys.platform == 'win32') and 'Scripts' or 'bin', 'activate_this.py')
     try:
-        f = open(activate).read()
+        fo = open(activate)
+        f = fo.read()
+        fo.close()
     except:
         f = activate_content
-        code = compile(f, activate, 'exec')
-        exec(code, dict(__file__=activate))
+
+    code = compile(f, activate, 'exec')
+    exec(code, dict(__file__=activate))
+
 
 def deactivate():
     global prev_syspath

--- a/autoload/pyvenv.py
+++ b/autoload/pyvenv.py
@@ -2,12 +2,45 @@ import vim, os, sys
 
 prev_syspath = None
 
+activate_content = """
+try:
+    __file__
+except NameError:
+    raise AssertionError(
+        "You must run this like execfile('path/to/activate_this.py', dict(__file__='path/to/activate_this.py'))")
+import sys
+import os
+
+old_os_path = os.environ['PATH']
+os.environ['PATH'] = os.path.dirname(os.path.abspath(__file__)) + os.pathsep + old_os_path
+base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if sys.platform == 'win32':
+    site_packages = os.path.join(base, 'Lib', 'site-packages')
+else:
+    site_packages = os.path.join(base, 'lib', 'python%s' % sys.version[:3], 'site-packages')
+prev_sys_path = list(sys.path)
+import site
+site.addsitedir(site_packages)
+sys.real_prefix = sys.prefix
+sys.prefix = base
+# Move the added items to the front of the path:
+new_sys_path = []
+for item in list(sys.path):
+    if item not in prev_sys_path:
+        new_sys_path.append(item)
+        sys.path.remove(item)
+sys.path[:0] = new_sys_path
+"""
+
 def activate(env):
     global prev_syspath
     prev_syspath = list(sys.path)
     activate = os.path.join(env, (sys.platform == 'win32') and 'Scripts' or 'bin', 'activate_this.py')
-    with open(activate) as f:
-        code = compile(f.read(), activate, 'exec')
+    try:
+        f = open(activate).read()
+    except:
+        f = activate_content
+        code = compile(f, activate, 'exec')
         exec(code, dict(__file__=activate))
 
 def deactivate():


### PR DESCRIPTION
virtualenv created by python 3 that installed by homebrew in OS X does
not automatically include activate_this.py, however, content of each
activate_this.py are the same.