### PR TITLE
Fix for Python version detection when using pyvenv

### DIFF
--- a/autoload/pyvenv.py
+++ b/autoload/pyvenv.py
@@ -2,7 +2,8 @@ import vim, os, sys
 
 prev_syspath = None
 
-activate_content = """
+def activate(env):
+    activate_content = """
 try:
     __file__
 except NameError:
@@ -17,7 +18,7 @@ base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if sys.platform == 'win32':
     site_packages = os.path.join(base, 'Lib', 'site-packages')
 else:
-    site_packages = os.path.join(base, 'lib', 'python%s' % sys.version[:3], 'site-packages')
+    site_packages = os.path.join(base, 'lib', 'python%s', 'site-packages')
 prev_sys_path = list(sys.path)
 import site
 site.addsitedir(site_packages)
@@ -30,9 +31,9 @@ for item in list(sys.path):
         new_sys_path.append(item)
         sys.path.remove(item)
 sys.path[:0] = new_sys_path
-"""
+""" % os.popen("%s --version" % os.path.join(env, "bin", "python")
+              ).readline().split()[1][:3]
 
-def activate(env):
     global prev_syspath
     prev_syspath = list(sys.path)
     activate = os.path.join(env, (sys.platform == 'win32') and 'Scripts' or 'bin', 'activate_this.py')


### PR DESCRIPTION
**The Issue**: if vim is using Python 2 by default, and pyvenv is created
using Python 3, then when forming an addition to the path Python 2 is
used. (Probably same will happen for vice versa situation). E.g. instead of
'~/.virtualenv/test_env/lib/python3.4/site-packages/' the string
'~/.virtualenv/test_env/lib/python2.7/site-packages/' will be added to
sys.path. This happens due to how activation script detects python
version.
**The Fix**: Detect Python version in the virtual environment instead of
detecting the one running the script.
