### PR TITLE
Add check for Pipenv when auto-detecting virtualenv

### DIFF
--- a/autoload/virtualenv.vim
+++ b/autoload/virtualenv.vim
@@ -13,8 +13,11 @@ function! virtualenv#activate(...)
     let name   = a:0 > 0 ? a:1 : ''
     let silent = a:0 > 1 ? a:2 : 0
     let env_dir = ''
-    if len(name) == 0  "Figure out the name based on current file
-        if isdirectory($VIRTUAL_ENV)
+    if len(name) == 0  "Figure out the name from Pipenv, or based on current file
+        let pipenv = matchstr(system('which pipenv > /dev/null && pipenv --venv'), '^/.\+')
+        if len(pipenv)
+            let env_dir = pipenv
+        elseif isdirectory($VIRTUAL_ENV)
             let name = fnamemodify($VIRTUAL_ENV, ':t')
             let env_dir = $VIRTUAL_ENV
         elseif isdirectory($PROJECT_HOME)


### PR DESCRIPTION
If the executable Pipenv exists, and returns a path when called, use the
output as the path to the virtual environment.

The order of the checks could be challenged, here, but personally I
believe that if Pipenv has an environment for the current directory, it
should probably be the active env. This makes it so you don't have to
worry about what else is in your environment when you change into the
project directory.

This is the first time I've ever done anything in Vim script, so I'm very open
to any suggestions or comments.