### PR TITLE
fixed activate's PATH addition on windows

### DIFF
--- a/autoload/virtualenv.vim
+++ b/autoload/virtualenv.vim
@@ -46,8 +46,10 @@ function! virtualenv#activate(...)
 
     " Prepend bin to PATH, but only if it's not there already
     " (activate_this does this also, https://github.com/pypa/virtualenv/issues/14)
-    if $PATH[:len(bin)] != bin.':'
-      let $PATH = bin.':'.$PATH
+    let PATHsep = has('win32') ? ';' : ':'
+
+    if $PATH[:len(bin)] != bin.PATHsep
+      let $PATH = bin.PATHsep.$PATH
     endif
 
     if has('python')


### PR DESCRIPTION
Fixed `virtualenv#activate` from breaking the rest of the path on Windows. Windows uses `;` to separate the PATH instead of `:`

#### My System Specs
OS: Windows 10 (version 21H1)    
Vim: Vim 9.0 (2022 Jun 28, compiled Oct 16 2022 22:04:13)   

#### Old Behavior
```vim
:echo $PATH
" C:\WINDOWS\System32;C:\WINDOWS;....

:call virtualenv#activate('testenv')

:echo $PATH
" C:\Users\neal\Envs/testenv/Scripts:C:\WINDOWS\System32;C:\WINDOWS;....
" Note: `Scripts:C:\`
```
